### PR TITLE
Fix for double copper / zinc generation

### DIFF
--- a/FULL/config/FlaxbeardsSteamPower.cfg
+++ b/FULL/config/FlaxbeardsSteamPower.cfg
@@ -201,8 +201,8 @@ weapons {
     B:"Generate End Zinc"=false
     B:"Generate Nether Copper"=false
     B:"Generate Nether Zinc"=false
-    B:"Generate Overworld Copper"=true
-    B:"Generate Overworld Zinc"=true
+    B:"Generate Overworld Copper"=false
+    B:"Generate Overworld Zinc"=false
     B:"Generate Zinc"=false
 }
 

--- a/MINI/config/FlaxbeardsSteamPower.cfg
+++ b/MINI/config/FlaxbeardsSteamPower.cfg
@@ -201,8 +201,8 @@ weapons {
     B:"Generate End Zinc"=false
     B:"Generate Nether Copper"=false
     B:"Generate Nether Zinc"=false
-    B:"Generate Overworld Copper"=true
-    B:"Generate Overworld Zinc"=true
+    B:"Generate Overworld Copper"=false
+    B:"Generate Overworld Zinc"=false
     B:"Generate Zinc"=false
 }
 


### PR DESCRIPTION
Disabled Flaxbeard's Steam Power Copper and Zinc generation, leaving
only the ones at cofh/world.