### PR TITLE
Change NuclearCraft Metal Furnace recipe. Fixes #903

### DIFF
--- a/BTP15/scripts/nc.zs
+++ b/BTP15/scripts/nc.zs
@@ -1,0 +1,5 @@
+# NuclearCraft
+
+# Change Metal Furnace recipe since it clashes with IC2 Basic Machine block (which is far more universally required)
+recipes.remove(<NuclearCraft:furnaceIdle>);
+recipes.addShaped(<NuclearCraft:furnaceIdle>, [[<ore:plateIron>, <ore:plateIron>, <ore:plateIron>], [<ore:plateIron>, <minecraft:furnace:*>, <ore:plateIron>], [<ore:plateIron>, <ore:plateIron>, <ore:plateIron>]]);


### PR DESCRIPTION
Recipe change to include Minecraft Furnace in the center. Required so that IC2 Basic Machine casing can be auto-crafted.
Changing the Metal Furnace has less impact than changing the IC2 basic machine casing as this is basically just adding 8 cobblestone to the recipe. Plus the recipe makes more sense now too.