### PR TITLE
Change Malisis' Doors curtain recipes to allow auto-crafting of Black Curtains. Fixes #904

### DIFF
--- a/BTP15/scripts/malisis.zs
+++ b/BTP15/scripts/malisis.zs
@@ -1,0 +1,37 @@
+# Malisis' Doors
+
+# Strip Curtain recipes as they clash with Black Curtains from EIO
+recipes.remove(<malisisdoors:item.curtain_black>);
+recipes.remove(<malisisdoors:item.curtain_red>);
+recipes.remove(<malisisdoors:item.curtain_green>);
+recipes.remove(<malisisdoors:item.curtain_brown>);
+recipes.remove(<malisisdoors:item.curtain_blue>);
+recipes.remove(<malisisdoors:item.curtain_purple>);
+recipes.remove(<malisisdoors:item.curtain_cyan>);
+recipes.remove(<malisisdoors:item.curtain_silver>);
+recipes.remove(<malisisdoors:item.curtain_gray>);
+recipes.remove(<malisisdoors:item.curtain_pink>);
+recipes.remove(<malisisdoors:item.curtain_lime>);
+recipes.remove(<malisisdoors:item.curtain_yellow>);
+recipes.remove(<malisisdoors:item.curtain_light_blue>);
+recipes.remove(<malisisdoors:item.curtain_magenta>);
+recipes.remove(<malisisdoors:item.curtain_orange>);
+recipes.remove(<malisisdoors:item.curtain_white>);
+
+# Add alternative recipes for Malisis' curtains (flipped to horizontal instead of vertical)
+recipes.addShapedMirrored(<malisisdoors:item.curtain_white>, [[<minecraft:wool:0>, <minecraft:wool:0>, <minecraft:wool:0>], [<minecraft:wool:0>,<minecraft:wool:0>,<minecraft:wool:0>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_orange>, [[<minecraft:wool:1>, <minecraft:wool:1>, <minecraft:wool:1>], [<minecraft:wool:1>,<minecraft:wool:1>,<minecraft:wool:1>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_magenta>, [[<minecraft:wool:2>, <minecraft:wool:2>, <minecraft:wool:2>], [<minecraft:wool:2>,<minecraft:wool:2>,<minecraft:wool:2>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_light_blue>, [[<minecraft:wool:3>, <minecraft:wool:3>, <minecraft:wool:3>], [<minecraft:wool:3>,<minecraft:wool:3>,<minecraft:wool:3>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_yellow>, [[<minecraft:wool:4>, <minecraft:wool:4>, <minecraft:wool:4>], [<minecraft:wool:4>,<minecraft:wool:4>,<minecraft:wool:4>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_lime>, [[<minecraft:wool:5>, <minecraft:wool:5>, <minecraft:wool:5>], [<minecraft:wool:5>,<minecraft:wool:5>,<minecraft:wool:5>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_pink>, [[<minecraft:wool:6>, <minecraft:wool:6>, <minecraft:wool:6>], [<minecraft:wool:6>,<minecraft:wool:6>,<minecraft:wool:6>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_gray>, [[<minecraft:wool:7>, <minecraft:wool:7>, <minecraft:wool:7>], [<minecraft:wool:7>,<minecraft:wool:7>,<minecraft:wool:7>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_silver>, [[<minecraft:wool:8>, <minecraft:wool:8>, <minecraft:wool:8>], [<minecraft:wool:8>,<minecraft:wool:8>,<minecraft:wool:8>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_cyan>, [[<minecraft:wool:9>, <minecraft:wool:9>, <minecraft:wool:9>], [<minecraft:wool:9>,<minecraft:wool:9>,<minecraft:wool:9>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_purple>, [[<minecraft:wool:10>, <minecraft:wool:10>, <minecraft:wool:10>], [<minecraft:wool:10>,<minecraft:wool:10>,<minecraft:wool:10>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_blue>, [[<minecraft:wool:11>, <minecraft:wool:11>, <minecraft:wool:11>], [<minecraft:wool:11>,<minecraft:wool:11>,<minecraft:wool:11>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_brown>, [[<minecraft:wool:12>, <minecraft:wool:12>, <minecraft:wool:12>], [<minecraft:wool:12>,<minecraft:wool:12>,<minecraft:wool:12>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_green>, [[<minecraft:wool:13>, <minecraft:wool:13>, <minecraft:wool:13>], [<minecraft:wool:13>,<minecraft:wool:13>,<minecraft:wool:13>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_red>, [[<minecraft:wool:14>, <minecraft:wool:14>, <minecraft:wool:14>], [<minecraft:wool:14>,<minecraft:wool:14>,<minecraft:wool:14>]]);
+recipes.addShapedMirrored(<malisisdoors:item.curtain_black>, [[<minecraft:wool:15>, <minecraft:wool:15>, <minecraft:wool:15>], [<minecraft:wool:15>,<minecraft:wool:15>,<minecraft:wool:15>]]);

--- a/BTP15/scripts/malisis.zs
+++ b/BTP15/scripts/malisis.zs
@@ -1,6 +1,6 @@
 # Malisis' Doors
 
-# Strip Curtain recipes as they clash with Black Curtains from EIO
+# Strip Curtain recipes as they clash with Black Curtains from XU
 recipes.remove(<malisisdoors:item.curtain_black>);
 recipes.remove(<malisisdoors:item.curtain_red>);
 recipes.remove(<malisisdoors:item.curtain_green>);


### PR DESCRIPTION
Recipes were flipped 90 degrees, so instead of a horizontal (door) shape, the recipes are now a vertical (Wall) shape. Doesn't change the recipe, while still allowing black curtains to be auto-crafted.
Auto-Crafting was previously only possible through the power of AE2 and it's oredict substituting recipe patterns. Other ways to auto-craft things fail to produce black curtains without this patch.