### PR TITLE
change bugged Uranium ore name to proper name

### DIFF
--- a/BTP15/scripts/nc.zs
+++ b/BTP15/scripts/nc.zs
@@ -3,3 +3,5 @@
 # Change Metal Furnace recipe since it clashes with IC2 Basic Machine block (which is far more universally required)
 recipes.remove(<NuclearCraft:furnaceIdle>);
 recipes.addShaped(<NuclearCraft:furnaceIdle>, [[<ore:plateIron>, <ore:plateIron>, <ore:plateIron>], [<ore:plateIron>, <minecraft:furnace:*>, <ore:plateIron>], [<ore:plateIron>, <ore:plateIron>, <ore:plateIron>]]);
+
+<NuclearCraft:blockOre:4>.displayName = "Uranium Ore";


### PR DESCRIPTION
I saw that the Uranium ore from Nuclearcraft is bugged out that is fixing the issue.
`<NuclearCraft:blockOre:4>.displayName = "Uranium Ore";`