### PR TITLE
disables death messages of named entities

### DIFF
--- a/BTP15/config/cofh/core/common.cfg
+++ b/BTP15/config/cofh/core/common.cfg
@@ -11,7 +11,7 @@ General {
     B:EnableDismantleLogging=false
 
     # Set to TRUE to display death messages for any named entity.
-    B:EnableGenericDeathMessage=true
+    B:EnableGenericDeathMessage=false
 
     # Set to FALSE to disable items on the ground from trying to stack. This can improve server performance.
     B:EnableItemStacking=true


### PR DESCRIPTION
disables the death messages of named entities because it will get annoying especially with an automated mobfarm.